### PR TITLE
Removed 4 unnecessary stubbings in OidcClientTest.java

### DIFF
--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcClientTest.java
@@ -179,7 +179,7 @@ public class OidcClientTest extends AbstractOidcTest {
 
   @Test
   public void getUserInfoFromUserInfoEndpoint() {
-    OidcClient underTest = newSpyOidcClientWithoutProfileInformation();
+    OidcClient underTest = newSpyOidcClientWithoutProfileInformation3();
     UserInfo userInfo = underTest.getUserInfo(new AuthorizationCode(VALID_CODE), CALLBACK_URL);
     assertEquals("e65c9607-fd4e-4bcd-97b1-ca057616590e", userInfo.getSubject().getValue());
     assertEquals("john.doo", userInfo.getPreferredUsername());
@@ -192,7 +192,7 @@ public class OidcClientTest extends AbstractOidcTest {
 
   @Test
   public void userInfoErrorResponse() {
-    OidcClient underTest = newSpyOidcClientWithoutProfileInformation();
+    OidcClient underTest = newSpyOidcClientWithoutProfileInformation2();
     UserInfoErrorResponse userInfoResponse = new UserInfoErrorResponse(new ErrorObject("some_error"));
     doReturn(userInfoResponse).when(underTest)
         .getUserInfoResponse(getProviderMetadata(ISSUER_URI).getUserInfoEndpointURI(), INVALID_BEARER_ACCESS_TOKEN);
@@ -207,7 +207,7 @@ public class OidcClientTest extends AbstractOidcTest {
 
   @Test
   public void userInfoErrorResponseWithoutErrorCode() {
-    OidcClient underTest = newSpyOidcClientWithoutProfileInformation();
+    OidcClient underTest = newSpyOidcClientWithoutProfileInformation2();
     UserInfoErrorResponse userInfoResponse = new UserInfoErrorResponse(new ErrorObject(null));
     doReturn(userInfoResponse).when(underTest)
         .getUserInfoResponse(getProviderMetadata(ISSUER_URI).getUserInfoEndpointURI(), INVALID_BEARER_ACCESS_TOKEN);
@@ -275,6 +275,36 @@ public class OidcClientTest extends AbstractOidcTest {
           getProviderMetadata(ISSUER_URI).getUserInfoEndpointURI(),
           tokenResponse.getOIDCTokens().getBearerAccessToken());
 
+      doCallRealMethod().when(client).getUserInfo(new AuthorizationCode(VALID_CODE), CALLBACK_URL);
+    } catch (ParseException | java.text.ParseException e) {
+      // ignore
+    }
+    return client;
+  }
+
+  private OidcClient newSpyOidcClientWithoutProfileInformation2() {
+    setSettings(true);
+    OidcClient client = createSpyOidcClient();
+    try {
+      OIDCTokenResponse tokenResponse = OIDCTokenResponse.parse(new JSONObject(JSONObjectUtils.parse("{\"id_token\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJlNjVjOTYwNy1mZDRlLTRiY2QtOTdiMS1jYTA1NzYxNjU5MGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvaHViIiwiYXVkIjpbIjYwZGNhY2FmLThhOTQtNDE3Ny1iMmYyLTEzNDg0NjNmODhjZSJdLCJleHAiOjEuNTIzNTcyMTY3NTYxRTksImlhdCI6MS41MTU3OTYxNjc1OTdFOSwiYXV0aF90aW1lIjoxLjUxNTc5NjE2NzU2MUU5fQ.o_h3f6QK--p1Ru8pUquoLpvB1vdBCorUfdq_I8J_yBbjyPS4LUP9-e_xkXtql6yOSh9AewNUb7PSKnJOq-TlMMMlOr-Or676i1wT0hGQb2aKnzzFu7VYQOep8_6t-AQSXRhckaR5NIJnF6oxFWdTwhizcenO_Osf12R-PQOyQsA\"," + "\"access_token\":\"1515799767598.60dcacaf-8a94-4177-b2f2-1348463f88ce.e65c9607-fd4e-4bcd-97b1-ca057616590e.0-0-0-0-0;1.MCwCFEjmjjDDL1yAQ+jYA+VxgYNNNr4hAhR66eAgXKfs6kOJehOALtRqw5wq9Q==\"," + "\"token_type\":\"Bearer\"," + "\"expires_in\":3600," + "\"scope\":\"0-0-0-0-0\"}")));
+      OIDCTokenResponse invalidTokenResponse = OIDCTokenResponse.parse(new JSONObject(JSONObjectUtils.parse("{\"id_token\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJlNjVjOTYwNy1mZDRlLTRiY2QtOTdiMS1jYTA1NzYxNjU5MGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvaHViIiwiYXVkIjpbIjYwZGNhY2FmLThhOTQtNDE3Ny1iMmYyLTEzNDg0NjNmODhjZSJdLCJleHAiOjEuNTIzNTcyMTY3NTYxRTksImlhdCI6MS41MTU3OTYxNjc1OTdFOSwiYXV0aF90aW1lIjoxLjUxNTc5NjE2NzU2MUU5fQ.o_h3f6QK--p1Ru8pUquoLpvB1vdBCorUfdq_I8J_yBbjyPS4LUP9-e_xkXtql6yOSh9AewNUb7PSKnJOq-TlMMMlOr-Or676i1wT0hGQb2aKnzzFu7VYQOep8_6t-AQSXRhckaR5NIJnF6oxFWdTwhizcenO_Osf12R-PQOyQsA\"," + "\"access_token\":\"invalid\"," + "\"token_type\":\"Bearer\"," + "\"expires_in\":3600," + "\"scope\":\"0-0-0-0-0\"}")));
+      doReturn(invalidTokenResponse).when(client).getTokenResponse(getProviderMetadata(ISSUER_URI).getTokenEndpointURI(), new AuthorizationCode(INVALID_CODE), CALLBACK_URL);
+      UserInfoSuccessResponse userInfoResponse = new UserInfoSuccessResponse(new UserInfo(new JSONObject(JSONObjectUtils.parse("{\"sub\":\"e65c9607-fd4e-4bcd-97b1-ca057616590e\"," + "\"name\":\"John Doo\",\"preferred_username\":\"john.doo\"," + "\"profile\":\"http://localhost:8080/hub/users/e65c9607-fd4e-4bcd-97b1-ca057616590e\"," + "\"email\":\"john.doo@acme.com\",\"email_verified\":true}"))));
+    } catch (ParseException | java.text.ParseException e) {
+      // ignore
+    }
+    return client;
+  }
+
+  private OidcClient newSpyOidcClientWithoutProfileInformation3() {
+    setSettings(true);
+    OidcClient client = createSpyOidcClient();
+    try {
+      OIDCTokenResponse tokenResponse = OIDCTokenResponse.parse(new JSONObject(JSONObjectUtils.parse("{\"id_token\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJlNjVjOTYwNy1mZDRlLTRiY2QtOTdiMS1jYTA1NzYxNjU5MGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvaHViIiwiYXVkIjpbIjYwZGNhY2FmLThhOTQtNDE3Ny1iMmYyLTEzNDg0NjNmODhjZSJdLCJleHAiOjEuNTIzNTcyMTY3NTYxRTksImlhdCI6MS41MTU3OTYxNjc1OTdFOSwiYXV0aF90aW1lIjoxLjUxNTc5NjE2NzU2MUU5fQ.o_h3f6QK--p1Ru8pUquoLpvB1vdBCorUfdq_I8J_yBbjyPS4LUP9-e_xkXtql6yOSh9AewNUb7PSKnJOq-TlMMMlOr-Or676i1wT0hGQb2aKnzzFu7VYQOep8_6t-AQSXRhckaR5NIJnF6oxFWdTwhizcenO_Osf12R-PQOyQsA\"," + "\"access_token\":\"1515799767598.60dcacaf-8a94-4177-b2f2-1348463f88ce.e65c9607-fd4e-4bcd-97b1-ca057616590e.0-0-0-0-0;1.MCwCFEjmjjDDL1yAQ+jYA+VxgYNNNr4hAhR66eAgXKfs6kOJehOALtRqw5wq9Q==\"," + "\"token_type\":\"Bearer\"," + "\"expires_in\":3600," + "\"scope\":\"0-0-0-0-0\"}")));
+      doReturn(tokenResponse).when(client).getTokenResponse(getProviderMetadata(ISSUER_URI).getTokenEndpointURI(), new AuthorizationCode(VALID_CODE), CALLBACK_URL);
+      OIDCTokenResponse invalidTokenResponse = OIDCTokenResponse.parse(new JSONObject(JSONObjectUtils.parse("{\"id_token\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjEifQ.eyJzdWIiOiJlNjVjOTYwNy1mZDRlLTRiY2QtOTdiMS1jYTA1NzYxNjU5MGUiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvaHViIiwiYXVkIjpbIjYwZGNhY2FmLThhOTQtNDE3Ny1iMmYyLTEzNDg0NjNmODhjZSJdLCJleHAiOjEuNTIzNTcyMTY3NTYxRTksImlhdCI6MS41MTU3OTYxNjc1OTdFOSwiYXV0aF90aW1lIjoxLjUxNTc5NjE2NzU2MUU5fQ.o_h3f6QK--p1Ru8pUquoLpvB1vdBCorUfdq_I8J_yBbjyPS4LUP9-e_xkXtql6yOSh9AewNUb7PSKnJOq-TlMMMlOr-Or676i1wT0hGQb2aKnzzFu7VYQOep8_6t-AQSXRhckaR5NIJnF6oxFWdTwhizcenO_Osf12R-PQOyQsA\"," + "\"access_token\":\"invalid\"," + "\"token_type\":\"Bearer\"," + "\"expires_in\":3600," + "\"scope\":\"0-0-0-0-0\"}")));
+      UserInfoSuccessResponse userInfoResponse = new UserInfoSuccessResponse(new UserInfo(new JSONObject(JSONObjectUtils.parse("{\"sub\":\"e65c9607-fd4e-4bcd-97b1-ca057616590e\"," + "\"name\":\"John Doo\",\"preferred_username\":\"john.doo\"," + "\"profile\":\"http://localhost:8080/hub/users/e65c9607-fd4e-4bcd-97b1-ca057616590e\"," + "\"email\":\"john.doo@acme.com\",\"email_verified\":true}"))));
+      doReturn(userInfoResponse).when(client).getUserInfoResponse(getProviderMetadata(ISSUER_URI).getUserInfoEndpointURI(), tokenResponse.getOIDCTokens().getBearerAccessToken());
       doCallRealMethod().when(client).getUserInfo(new AuthorizationCode(VALID_CODE), CALLBACK_URL);
     } catch (ParseException | java.text.ParseException e) {
       // ignore


### PR DESCRIPTION
[ARUS2023](https://github.com/ARUS2023) commented [on Oct 5, 2023](https://github.com/vaulttec/sonar-auth-oidc/pull/72#issue-1928702037) •

> In our analysis of the project, we observed that
> 
> 1. 3 unnecessary stubbings which stubbed `getUserInfo`, `getTokenResponse`(returned `tokenResponse`) and `getUserInfoResponse` are created but never executed by 2 tests: `OidcClientTest.userInfoErrorResponse`, `OidcClientTest.userInfoErrorResponseWithoutErrorCode`;
> 2. 1 unnecessary stubbing which stubbed `getTokenResponse` (returned `invalidTokenResponse`) is created but never executed by 1 test: `OidcClientTest.getUserInfoFromUserInfoEndpoint`;
> 
> Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).
> 
> We propose below a solution to remove the unnecessary stubbings.